### PR TITLE
Add Codex CLI plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "mcp-server",
+  "version": "0.1.0",
+  "description": "An MCP server for interacting with the Financial Datasets stock market API.",
+  "author": {
+    "name": "financial-datasets",
+    "url": "https://github.com/financial-datasets"
+  },
+  "homepage": "https://github.com/financial-datasets/mcp-server",
+  "repository": "https://github.com/financial-datasets/mcp-server",
+  "keywords": [
+    "mcp",
+    "codex"
+  ],
+  "mcpServers": "./.mcp.json"
+}

--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,0 +1,22 @@
+name: Codex Plugin Quality Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: codex-plugin-scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Codex plugin scanner
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@b45d6b583afe05819b24edc8e6418c9ad2e1f1d0 # v1

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "mcp-server": {
+      "command": "npx",
+      "args": [
+        "financial-datasets-mcp-server"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
I opened this as a small metadata pass for the Codex plugin surface in the repo.

A couple of repo-specific details I checked first:
- An MCP server for interacting with the Financial Datasets stock market API
- Financial Datasets MCP Server
- This is a Model Context Protocol (MCP) server that provides access to stock market data from Financial Datasets

This PR adds the Codex plugin metadata, an `.mcp.json` starting point, and the scanner workflow.
If you want different command wiring or manifest metadata, I can adjust the branch.