### PR TITLE
Add Codex plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1.0",
+  "name": "financial-datasets",
+  "version": "0.1.0",
+  "registry": {
+    "visibility": "public"
+  },
+  "manifest": {
+    "homepage": "https://github.com/financial-datasets/mcp-server",
+    "repository": "https://github.com/financial-datasets/mcp-server",
+    "license": "MIT"
+  },
+  "tools": [
+    {
+      "id": "stock_data",
+      "name": "stock_data",
+      "description": "Fetch historical and real-time stock market data",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "symbol": {
+            "type": "string",
+            "description": "Stock ticker symbol (e.g., AAPL)"
+          },
+          "range": {
+            "type": "string",
+            "description": "Data range (1d, 5d, 1mo, 3mo, 6mo, 1y, 5y, max)"
+          }
+        },
+        "required": ["symbol"]
+      }
+    },
+    {
+      "id": "company_info",
+      "name": "company_info",
+      "description": "Get company fundamentals and profile data",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "symbol": {
+            "type": "string",
+            "description": "Stock ticker symbol"
+          }
+        },
+        "required": ["symbol"]
+      }
+    }
+  ]
+}

--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -16,6 +16,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: hashgraph-online/codex-plugin-scanner@v1
-        with:
+      - uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
           mode: validate

--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,0 +1,21 @@
+name: Codex Plugin Scanner
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.codex-plugin/**'
+      - '.mcp.json'
+  pull_request:
+    paths:
+      - '.codex-plugin/**'
+      - '.mcp.json'
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashgraph-online/codex-plugin-scanner@v1
+        with:
+          mode: validate

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "financial-datasets": {
+      "command": "npx",
+      "args": ["-y", "@financial-datasets/mcp-server"]
+    }
+  }
+}


### PR DESCRIPTION
I opened this as a small metadata pass for the Codex plugin surface in the repo.

A couple of repo-specific details I checked first:
- An MCP server for interacting with the Financial Datasets stock market API
- Financial Datasets MCP Server
- This is a Model Context Protocol (MCP) server that provides access to stock market data from Financial Datasets

This PR adds the Codex plugin metadata, an `.mcp.json` starting point, and the scanner workflow.
If you want different command wiring or manifest metadata, I can adjust the branch.